### PR TITLE
feat: compile main thread code with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "yarn build-main && yarn build-renderer",
-    "build-main": "tsc",
-    "watch-main": "yarn build-main --watch",
-    "build-renderer": "yarn webpack --config webpack.config.js",
+    "build": "yarn webpack --config webpack.config.js",
+	"clean": "rm -rf ./lib",
+    "watch": "yarn build --watch",
     "watch-renderer": "yarn build-renderer --watch",
     "prepare": "yarn run build",
-    "watch": "yarn run build --watch",
     "lint": "eslint .",
     "test": "yarn jest src/**/*.test.ts"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,15 @@
+/* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const path = require('path');
 
 module.exports = {
-	entry: [
-		path.join(__dirname, 'src', 'renderer.tsx'),
-	],
+	context: path.resolve(__dirname, 'src'),
+	entry: {
+		renderer: './renderer.tsx',
+		main: './main.ts',
+	},
 	externals: [
 		'@getflywheel/local/renderer',
+		'@getflywheel/local/main',
 		'react',
 		'@getflywheel/local-components',
 		'react-dom',
@@ -53,6 +57,7 @@ module.exports = {
 	},
 	node: {
 		fs: 'empty',
+		/* eslint-disable-next-line camelcase */
 		child_process: 'empty',
 		__dirname: false,
 	},
@@ -60,7 +65,7 @@ module.exports = {
 		extensions: ['.tsx', '.ts', '.jsx', '.js'],
 	},
 	output: {
-		filename: 'renderer.js',
+		filename: '[name].js',
 		path: path.join(__dirname, 'lib'),
 		libraryTarget: 'commonjs2',
 	},


### PR DESCRIPTION
### Summary

Instead of using the Typescript compiler directly, this lets us use webpack to bundle that main thread code. The benefit here is that our bundle size will likely be smaller in most scenarios. Plus, it lets us simplify the build scripts 😄 