### PR TITLE
fix: update hook names and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   },
   "bundledDependencies": [
     "@getflywheel/local-components",
-    "@getflywheel/local",
     "@getflywheel/local-browsersync",
     "fs-extra",
 	"get-port",

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ export default function (context: typeof serviceContainer.addonLoader.addonConte
 	);
 
 	HooksMain.addFilter(
-		'liveLinksProServiceStartPort',
+		'liveLinksServiceStartPort',
 		(port: number, site: Local.Site) => {
 			const instance = instantReload.getInstanceData(site.id);
 
@@ -54,7 +54,7 @@ export default function (context: typeof serviceContainer.addonLoader.addonConte
 	);
 
 	HooksMain.addFilter(
-		'liveLinksProServiceStartHostname',
+		'liveLinksServiceStartHostname',
 		(hostname: number, site: Local.Site) => {
 			const instance = instantReload.getInstanceData(site.id);
 


### PR DESCRIPTION
## Summary 

Note that these changes are already in the packed and published version of Instant Reload 1.1.0, hence no version bump with this.

* Updates the hooks so Instant Reload works over Live Links
* Removes unnecessary bundled dependencies that were causing the packed version of the addon to be ~100mb instead of 13mb