### PR TITLE
Ceanup browser sync processes

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,12 @@
+import { getServiceContainer } from "@getflywheel/local/main";
+
+const { localLogger } = getServiceContainer().cradle;
+
+/**
+ * An InstantReload scoped child logger
+ */
+const log = localLogger.child({
+	addon: 'InstantReload',
+});
+
+export default log;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,16 @@
 import * as Local from '@getflywheel/local';
+import { asValue } from 'awilix';
 import { getServiceContainer, HooksMain, addIpcAsyncListener } from '@getflywheel/local/main';
 import InstantReload from './main/InstantReload';
 import { IPC_EVENTS } from './constants';
 
-const serviceContainer = getServiceContainer().cradle;
+const localContainer = getServiceContainer();
+const serviceContainer = localContainer.cradle;
 
 export default function (context: typeof serviceContainer.addonLoader.addonContext): void {
 	const instantReload = new InstantReload();
+
+	localContainer.register({ instantReload: asValue(instantReload) } as any);
 
 	HooksMain.addAction('siteStarted', async (site: Local.Site) => {
 		try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { asValue } from 'awilix';
 import { getServiceContainer, HooksMain, addIpcAsyncListener } from '@getflywheel/local/main';
 import InstantReload from './main/InstantReload';
 import { IPC_EVENTS } from './constants';
+import log from './logger';
 
 const localContainer = getServiceContainer();
 const serviceContainer = localContainer.cradle;
@@ -98,7 +99,7 @@ export default function (context: typeof serviceContainer.addonLoader.addonConte
 		try {
 			result = serviceContainer.siteData.updateSite(siteID, { autoEnableInstantReload });
 		} catch (err) {
-			console.error(err);
+			log.error(`Unable to enable InstantReload for ${siteID}: ${err.message}`);
 		}
 
 		return result;

--- a/src/main/InstantReload.ts
+++ b/src/main/InstantReload.ts
@@ -10,6 +10,7 @@ import {
 } from '@getflywheel/local/main';
 import { IPC_EVENTS, INSTANT_RELOAD_EVENTS } from '../constants';
 import { STATUSES, InstantReloadStatus } from '../types';
+import log from '../logger';
 
 const serviceContainer = getServiceContainer().cradle;
 
@@ -26,8 +27,6 @@ export default class InstantReloadService {
 
 	private _sendIPCEvent: typeof serviceContainer.sendIPCEvent;
 
-	private _localLogger: typeof serviceContainer.localLogger;
-
 	/**
 	 * hash map of all browser sync instances by site id
 	 */
@@ -42,11 +41,10 @@ export default class InstantReloadService {
 	}
 
 	constructor () {
-		const { localLogger, siteData, sendIPCEvent } = serviceContainer;
+		const { siteData, sendIPCEvent } = serviceContainer;
 
 		this._siteData = siteData;
 		this._sendIPCEvent = sendIPCEvent;
-		this._localLogger = localLogger;
 	}
 
 	/**
@@ -105,11 +103,11 @@ export default class InstantReloadService {
 		 */
 		try {
 			instanceData.childProcess.kill();
-			this._localLogger.info(
+			log.info(
 				`Killing Instant Reload child process for ${site.name}.`,
 			);
 		} catch (err) {
-			this._localLogger.debug(`Error killing Instant Reload child process for ${site.name}. ${err}`);
+			log.error(`Error killing Instant Reload child process for ${site.name}. ${err}`);
 		}
 
 		this._browserSyncInstances[site.id] = null;


### PR DESCRIPTION
In this [Forum thread](https://community.localwp.com/t/site-stuck-in-loading/39669?u=ben.turner), users reported that sites with Instant Reload enabled were unresponsive after upgrading Local Core.

This PR registers an `onDestroy` method with Local Core's service class so that various BrowserSync processes can be cleanly closed when the app quits. 