### PR TITLE
[LOC-6182] Fix instant reload in Local 9.1.1+

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,24 @@ export default function (context: typeof serviceContainer.addonLoader.addonConte
 	);
 
 	HooksMain.addFilter(
+		'routerServiceLocationBlocks',
+		(locationBlocks: string, site: Local.Site) => {
+			const instance = instantReload.getInstanceData(site.id);
+			if (instance?.hostname && instance?.port) {
+				const browserSyncBlock = `
+		# BrowserSync WebSocket support
+		location ^~ /browser-sync/socket.io/ {
+			proxy_set_header Connection upgrade;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_pass http://${instance.hostname}:${instance.port};
+		}`;
+				return locationBlocks + browserSyncBlock;
+			}
+			return locationBlocks;
+		},
+	);
+
+	HooksMain.addFilter(
 		'liveLinksServiceStartPort',
 		(port: number, site: Local.Site) => {
 			const instance = instantReload.getInstanceData(site.id);

--- a/src/main/instantReloadProcess.ts
+++ b/src/main/instantReloadProcess.ts
@@ -95,12 +95,7 @@ const handleCreate = async (payload) => {
 				],
 				proxyRes: [
 					(proxyRes) => {
-						// sets response header 'transfer-encoding' to undefined when running integration tests
-						// this header was causing parse errors when the proxy URL was called by fetch()
-						if (typeof process.env.JEST_WORKER_ID !== 'undefined') {
-							/* eslint-disable-next-line no-param-reassign */
-							proxyRes.headers['transfer-encoding'] = null;
-						}
+						delete proxyRes.headers['transfer-encoding'];
 					},
 				],
 			},


### PR DESCRIPTION
## Bug details

In Local 9.1 we updated Local's nginx router config to support Server Sent Events, which involved changing from HTTP 1.0
to HTTP 1.1 to enable persistent connections.

This accidentally broke Live Reload — Local's router would 502 if users had Live Reload active on a site, with an error in Local's nginx router logs like this:

```
upstream sent "Content-Length" and "Transfer-Encoding" headers
at the same time
```

For example: https://community.localwp.com/t/instant-reload-502-error/44869/17

## What this PR changes

This PR makes two fixes:

1. Deletes the `transfer-encoding` header in the proxy response to prevent the 502 error.
2. Injects a location block into Local's router to enable WebSocket support for browser sync under HTTP 1.1. This depends on a new filter called `routerServiceLocationBlocks` that we'll add to Local 9.1.1.

When these fixes are deployed, users will need to update both Instant Reload (to version 1.1.4+) and Local (to version 9.1.1+) to restore live reload behavior.

## To test
Will provide testing instructions in the accompanying [Local PR](https://github.com/getflywheel/flywheel-local/pull/2067) (private repo).