### PR TITLE
chore: update engines to 9.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lodash"
   ],
   "engines": {
-    "local-by-flywheel": ">=6.1.1"
+    "local-by-flywheel": ">=9.1.1"
   },
   "resolutions": {
     "ansi-regex": "5.0.1",


### PR DESCRIPTION
Local 9.1.1 introduced a routerServiceLocationBlocks filter that we use in main.ts to update the nginx router location block. Props to @bgturner for the suggestion.

I think 9.1.1 is ok as the minimum so that it works with the beta too. Beta versions from `process.localVersion` look like `9.1.1+local-beta-1234` but the build info following `+` is stripped in version comparisons:

```JS
const semver = require('semver');

const localBetaVersion = '9.1.1+local-beta-1234';
const requirement = '>=9.1.1';

console.log(semver.satisfies(localBetaVersion, requirement));
```

```shell
> node index.js
true
```