### PR TITLE
[NOJIRA] fix: correct add-on slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "bgColor": "#51bb7b",
   "icon": "icon.svg",
-  "slug": "local-addon-instant-reload",
+  "slug": "instant-reload",
   "description": "A Local addon that provides live browser reloading while developing WordPress sites.",
   "renderer": "lib/renderer.js",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-instant-reload",
   "productName": "Instant Reload",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "Local Team",
   "keywords": [
     "local-addon"


### PR DESCRIPTION
Resolves #33 by using the same slug as the add-on server:

![CleanShot 2025-04-22 at 16 28 17@2x](https://github.com/user-attachments/assets/70351c59-bb84-4edb-a8b8-7e98fa3acb4f)

And the same expected slug as the add-on page (window.location when you click the add-on title in the installed add-ons screen):

"file:///Applications/Local.app/Contents/Resources/app.asar/renderer/_browserWindows/app/app.html#/main/marketplace/addon/instant-reload"

## To test

### Check the link now works

1. Run `yarn && npm pack`.
2. Install and activate the resulting add-on.
3. Visit Add-ons → Installed and click the add-on title or image.

You should see the add-on info instead of the error from #33.

![CleanShot 2025-04-22 at 16 57 53@2x](https://github.com/user-attachments/assets/4c46311d-b35a-4482-ad0b-17a6dc1187e3)

![CleanShot 2025-04-22 at 16 58 32@2x](https://github.com/user-attachments/assets/47d1ad6e-e0c6-4045-be33-ced5a7e73c91)


### Check updates are still available

If you quit Local, edit `~/Library/Application Support/Local/addons/@getflywheel-local-addon-instant-reload/package.json` to reduce the `version` to 1.1.3, then start Local, you should still see an update prompt for the add-on:

![CleanShot 2025-04-22 at 17 00 41@2x](https://github.com/user-attachments/assets/6e34d176-6488-4ca7-9a58-4f5ac1815483)